### PR TITLE
Adding repo name, and altering shebang

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 var async = require('async')
 var Table = require('easy-table')
 var exec = require('child_process').exec

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "module_footprints",
   "version": "1.0.2",
   "description": "",
+  "repository": "david-martin/module_footprints",
   "main": "index.js",
   "bin": "index.js",
   "scripts": {


### PR DESCRIPTION
Seeing an error with the shebang used on macOS:

```
$ module_footprints
zsh: /Users/jmadigan/.nvm/versions/node/v6.11.3/bin/module_footprints: bad interpreter: /bin/env: no such file or directory
```

Switched to `#!/usr/bin/env node`. Also added a repository field to `package.json`.