### PR TITLE
Handle misbehaving modules when required

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,20 +14,26 @@ async.mapSeries(Object.keys(list), function (dep, cb) {
   console.log('Running test for ' + dep)
   var options = {
     cwd: process.cwd(),
-    env: process.env
+    env: process.env,
+    timeout: 5000
   }
   options.env.TEST_MODULE_NAME = dep
   exec('node ' + path.dirname(__filename) + '/test.js', options, function (err, stdout) {
     if (err) {
-      return cb(err)
+      return cb()
+      console.log('Error parsing : ' + dep + err );
     }
     console.log('stdout', stdout)
+try{
     var memoryUsageDiff = JSON.parse(stdout)
     t.cell('Module Name', memoryUsageDiff.name)
     t.cell('RSS Diff', memoryUsageDiff.rss, formatMB)
     t.cell('Heap Total Diff', memoryUsageDiff.heapTotal, formatMB)
     t.cell('Heap Used Diff', memoryUsageDiff.heapUsed, formatMB)
     t.newRow()
+} catch (err) {
+console.log('Error parsing : ' + dep );
+}
     return cb()
   })
 }, function (err) {

--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ async.mapSeries(Object.keys(list), function (dep, cb) {
   options.env.TEST_MODULE_NAME = dep
   exec('node ' + path.dirname(__filename) + '/test.js', options, function (err, stdout) {
     if (err) {
-      return cb()
       console.log('Error parsing : ' + dep + err );
+      return cb()
     }
     console.log('stdout', stdout)
 try{
@@ -32,7 +32,7 @@ try{
     t.cell('Heap Used Diff', memoryUsageDiff.heapUsed, formatMB)
     t.newRow()
 } catch (err) {
-console.log('Error parsing : ' + dep );
+  console.log('Error parsing : ' + dep );
 }
     return cb()
   })


### PR DESCRIPTION
@david-martin - not applicable for most modules, but maybe of some use.
But I have tested with some modules that load modules dynamically at runtime. So require on a single module fails. Ignoring these errors still gives useful information for other dependencies with this tool.
